### PR TITLE
feat: improve how to use resource_group in modules

### DIFF
--- a/modules/customer-gateway/outputs.tf
+++ b/modules/customer-gateway/outputs.tf
@@ -46,3 +46,19 @@ output "certificate" {
 #     if !contains(["device_name", "type", "ip_address", "tags", "tags_all", "arn", "id", "certificate_arn", "bgp_asn", "bgp_asn_extended"], k)
 #   }
 # }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/customer-gateway/resource-group.tf
+++ b/modules/customer-gateway/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/customer-gateway/variables.tf
+++ b/modules/customer-gateway/variables.tf
@@ -63,23 +63,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/vpn-connection/outputs.tf
+++ b/modules/vpn-connection/outputs.tf
@@ -276,3 +276,19 @@ output "tunnel2_ike" {
 #     if !contains(["customer_gateway_id", "customer_gateway_configuration", "type", "tags", "tags_all", "arn", "id", "enable_acceleration", "static_routes_only", "vpn_gateway_id", "transit_gateway_id", "core_network_arn", "core_network_attachment_arn", "tunnel_inside_ip_version", "local_ipv4_network_cidr", "local_ipv6_network_cidr", "remote_ipv4_network_cidr", "remote_ipv6_network_cidr", "transit_gateway_attachment_id", "outside_ip_address_type", "tunnel1_address", "tunnel1_inside_cidr", "tunnel1_inside_ipv6_cidr", "tunnel1_cgw_inside_address", "tunnel1_vgw_inside_address", "tunnel1_preshared_key", "tunnel1_ike_versions", "tunnel1_phase1_encryption_algorithms", "tunnel1_phase1_integrity_algorithms", "tunnel1_phase1_dh_group_numbers", "tunnel1_phase1_lifetime_seconds", "tunnel1_phase2_encryption_algorithms", "tunnel1_phase2_integrity_algorithms", "tunnel1_phase2_dh_group_numbers", "tunnel1_phase2_lifetime_seconds", "tunnel1_dpd_timeout_seconds", "tunnel1_dpd_timeout_action", "tunnel1_enable_tunnel_lifecycle_control", "tunnel1_bgp_asn", "tunnel1_bgp_holdtime", "tunnel1_startup_action", "tunnel1_replay_window_size", "tunnel1_rekey_margin_time_seconds", "tunnel1_rekey_fuzz_percentage", "tunnel2_address", "tunnel2_inside_cidr", "tunnel2_inside_ipv6_cidr", "tunnel2_cgw_inside_address", "tunnel2_vgw_inside_address", "tunnel2_preshared_key", "tunnel2_ike_versions", "tunnel2_phase1_encryption_algorithms", "tunnel2_phase1_integrity_algorithms", "tunnel2_phase1_dh_group_numbers", "tunnel2_phase1_lifetime_seconds", "tunnel2_phase2_encryption_algorithms", "tunnel2_phase2_integrity_algorithms", "tunnel2_phase2_dh_group_numbers", "tunnel2_phase2_lifetime_seconds", "tunnel2_dpd_timeout_seconds", "tunnel2_dpd_timeout_action", "tunnel2_enable_tunnel_lifecycle_control", "tunnel2_bgp_asn", "tunnel2_bgp_holdtime", "tunnel2_startup_action", "tunnel2_replay_window_size", "tunnel2_rekey_margin_time_seconds", "tunnel2_rekey_fuzz_percentage", "vgw_telemetry"], k)
 #   }
 # }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/vpn-connection/resource-group.tf
+++ b/modules/vpn-connection/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/vpn-connection/variables.tf
+++ b/modules/vpn-connection/variables.tf
@@ -658,23 +658,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }


### PR DESCRIPTION
## Summary
Update resource group configuration to use object-based pattern.

## Changes
- Update module version from ~> 0.10.0 to ~> 0.12.0
- Replace individual resource_group_* variables with single object variable  
- Update all references to use var.resource_group.* structure
- Add resource_group output to each module

## Modules Updated
- customer-gateway
- vpn-connection

## Test Plan
- [ ] Review variable changes
- [ ] Verify resource-group module references are correct  
- [ ] Check outputs are properly formatted